### PR TITLE
Runner image: fix permisisons

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -98,6 +98,10 @@ WORKDIR /home/runner
 
 # We need to do some setup as the runner
 USER runner
+ENV HOME="/home/runner"
+# .profile doesn't get sourced, so we need to add these manually
+# This is a bit hacky as root user will also have /home/runner in its path.
+ENV PATH="$HOME/bin:$HOME/.local/bin:$PATH"
 
 # We may want to change to install globally, I think that is being done here
 # by setting the PIPX_BIN_DIR to something in the path.

--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -94,6 +94,13 @@ RUN chmod +x /actions-runner/start_runner.sh
 COPY setup_docker.sh /usr/local/bin/setup_docker.sh
 RUN chmod +x /usr/local/bin/setup_docker.sh
 
+# Mirror permissions from GitHub hosted runner. Note that in experimentation
+# it appears that facl has been set, but I don't see that being done in this
+# repo.
+# https://github.com/actions/runner-images/blob/1ed26a6d42b1c856759a31823c9d99b9775cb5fa/images/ubuntu/scripts/build/configure-system.sh#L15
+RUN chmod -R 777 /opt && \
+    chmod -R 777 /usr/share
+
 WORKDIR /home/runner
 
 # We need to do some setup as the runner


### PR DESCRIPTION
/opt and /usr/share both are set to 777 on GitHub's version of the Ubuntu image. I came into permissions issues when testing common workflows.

Note it appears additional extended permissions are set from testing the GitHub runner:
```
# file: /usr/share
# owner: root
# group: root
user::rwx
group::rwx
other::rwx
default:user::rwx
default:user:runner:rwx	#effective:rwx
default:group::rwx	#effective:rwx
default:mask::rwx
default:other::rwx
```

But I can't find any instance of `setfacl` in actions/runner-images so I'm not certain where that was coming from. Leaving as a simple chmod for now.