### PR TITLE
Implement Timeout For Runners That Don't Get Jobs

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get -y install \
 
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV IDLE_TIMEOUT_SECONDS=300
 
 ARG ACTION_RUNNER_VERSION=2.326.0
 ARG GH_VERSION=2.75.1
@@ -94,6 +95,11 @@ RUN curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/downl
     && tar xzf ./runner.tar.gz \
     && rm runner.tar.gz \
     && rm -rf /var/lib/apt/lists/*
+
+# Copy pre-run script and add it to actions runner config file
+COPY pre-run.sh /actions-runner/pre-run.sh
+RUN chmod +x /actions-runner/pre-run.sh \
+    && echo "ACTIONS_RUNNER_HOOK_JOB_STARTED=/actions-runner/pre-run.sh" >> /actions-runner/.env
 
 RUN /actions-runner/bin/installdependencies.sh \
     && adduser --disabled-password --gecos "" --uid 1001 runner \
@@ -152,7 +158,8 @@ RUN chmod +x /actions-runner/start_runner.sh
 COPY setup_docker.sh /usr/local/bin/setup_docker.sh
 RUN chmod +x /usr/local/bin/setup_docker.sh
 
-# Mirror permissions from GitHub hosted runner. Note that in experimentation
+# Mirror permissions from GitHub hosted runner.
+# Note that in experimentation
 # it appears that facl has been set, but I don't see that being done in this
 # repo.
 # https://github.com/actions/runner-images/blob/1ed26a6d42b1c856759a31823c9d99b9775cb5fa/images/ubuntu/scripts/build/configure-system.sh#L15

--- a/runner/pre-run.sh
+++ b/runner/pre-run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+LOCK_FILE="/tmp/runner.lock"
+touch "${LOCK_FILE}"
+echo "Runner lock file created at ${LOCK_FILE}. Idle timeout is now disabled."

--- a/runner/start_runner.sh
+++ b/runner/start_runner.sh
@@ -1,12 +1,36 @@
 #!/bin/bash
 set -euo pipefail
 
-#!/bin/bash
-set -euo pipefail
-
 # Uncompress the Just-In-Time configuration.
 ENCODED_JIT_CONFIG="$(echo "${ENCODED_JIT_CONFIG}" | base64 -d | gunzip)"
 
-# Start the runner. The DOCKER_HOST variable is inherited from the parent process.
+
+IDLE_TIMEOUT_SECONDS="${IDLE_TIMEOUT_SECONDS:-300}" # Default to 5 minutes
+LOCK_FILE="/tmp/runner.lock"
+
+# Start the runner in the background.
+# The DOCKER_HOST variable is inherited from the parent process.
 /actions-runner/run.sh --jitconfig "${ENCODED_JIT_CONFIG}" &
-wait $!
+RUNNER_PID=$!
+
+echo "Runner started with PID ${RUNNER_PID}. Idle timeout is ${IDLE_TIMEOUT_SECONDS} seconds."
+
+# Start a child process that will kill the runner after the timeout.
+(
+  sleep "${IDLE_TIMEOUT_SECONDS}"
+  if [[ ! -f "${LOCK_FILE}" ]]; then
+    echo "Runner has been idle for ${IDLE_TIMEOUT_SECONDS} seconds. Terminating."
+    kill "${RUNNER_PID}"
+  else
+    echo "Runner is busy, idle timeout disabled."
+  fi
+) &
+KILLER_PID=$!
+
+# Wait for the runner to complete a job and exit.
+wait "${RUNNER_PID}"
+
+# If the runner exits, it means it ran a job, so we don't need the killer process anymore.
+kill "${KILLER_PID}"
+# Clean up the lock file on exit
+rm -f "${LOCK_FILE}"


### PR DESCRIPTION
Currently if we schedule a runner but the job gets canceled before the runner can pick it up, it will keep running until the cloud build context ends. This is problematic for multiple reasons:

- When a new runner image is pushed, we don't know if new jobs being scheduled are running on the new or old runner image, making validation difficult.
- If a job gets scheduled and is picked up by a runner that is about to exceed its cloud build context, the job could crash halfway through processing.
- We pay the compute price for keeping the extra runner open. (Normally not a huge issue, but problematic if a bug is causing lots of runners to be started without jobs)

Additionally, this change enables two new possible features:
1. Spawning extra runners to clear out  job queues in the event jobs are scheduled but runner web hook fails  for some reason. We can spawn extra runners knowing if they don't pick up jobs they will not be leaked.
2. Pooling extra runners, to increase startup latency at the cost of more compute. This requires expiration for the same reason any runner that doesn't have a job does.

There is a race condition that is introduced:
There is some amount of time between a job being picked up by a runner and the `pre-run.sh` script creating the lockfile. If the timeout happens between these two times, then the job will be canceled. This is inherent to the design of the actions runner, there is no completely safe way to terminate a waiting runner.