### PR TITLE
Integration test: switch js command to node

### DIFF
--- a/.github/workflows/integration-test-minty.yml
+++ b/.github/workflows/integration-test-minty.yml
@@ -84,4 +84,4 @@ jobs:
           --search "Minty Test Pull Request updated:>=$(date -u -Iseconds -d "1 minute ago")" \
           --limit 1 \
           --json id \
-          | js ".[0].id" -e
+          | node ".[0].id" -e


### PR DESCRIPTION
`js` is symlinked on my dev box to node, I thought the symlink also existed on the ubuntu-latest runner but I was mistaken.