### PR TITLE
Integration Test:  js was supposed to be jq

### DIFF
--- a/.github/workflows/integration-test-minty.yml
+++ b/.github/workflows/integration-test-minty.yml
@@ -84,4 +84,4 @@ jobs:
           --search "Minty Test Pull Request updated:>=$(date -u -Iseconds -d "1 minute ago")" \
           --limit 1 \
           --json id \
-          | node ".[0].id" -e
+          | jq ".[0].id" -e


### PR DESCRIPTION
In #121 I did make the correct change, but it wasn't the one I was looking for.

I had mistyped `jq` as `js` when I wrote this, and `js` just happened to be a correct command, leading me down the wrong path, thinking `js` was supposed to be node.