### PR TITLE
docs: update deployment documentation

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'The full image tag (e.g., 2023-10-26.1) to promote to production.'
+        description: 'The commit SHA of the image to promote to production.'
         required: true
         type: 'string'
 


### PR DESCRIPTION
- Add a Deployment section to README.md detailing the webhook and runner deployment processes.
- Clarify the 'image_tag' input in the production promotion workflow to specify it expects a commit SHA.