### PR TITLE
feat: introduce runner-label flag for webhook

### DIFF
--- a/cmd/generate-jit/main.go
+++ b/cmd/generate-jit/main.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/google/go-github/v69/github"
@@ -37,7 +36,7 @@ var (
 	privateKeyPath = flag.String("private-key", "", "Path to your private key PEM file")
 	orgName        = flag.String("org", "", "GitHub organization name")
 	runnerName     = flag.String("runner-name", "my-gcp-runner", "Name for the new runner")
-	runnerLabels   = flag.String("runner-labels", "self-hosted,Linux,X64", "Comma-separated labels for the runner")
+	runnerLabel    = flag.String("runner-label", "self-hosted", "The single label for the runner")
 	runnerGroupID  = flag.Int64("runner-group-id", 1, "The ID of the runner group to assign the new runner to")
 )
 
@@ -96,7 +95,7 @@ func realMain(ctx context.Context) error {
 	jitconfig, _, err := gh.Actions.GenerateOrgJITConfig(ctx, *orgName, &github.GenerateJITConfigRequest{
 		Name:          *runnerName,
 		RunnerGroupID: *runnerGroupID,
-		Labels:        strings.Split(*runnerLabels, ","),
+		Labels:        []string{*runnerLabel},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to generate jitconfig: %w", err)

--- a/cmd/webhook-tester/main_test.go
+++ b/cmd/webhook-tester/main_test.go
@@ -108,6 +108,8 @@ func TestWebhookHarness(t *testing.T) {
 		Environment:      "autopush",
 		RunnerImageTag:   "latest",
 		GitHubAPIBaseURL: fakeGitHub.URL,
+		ExtraRunnerCount: "0",
+		RunnerLabel:      "self-hosted",
 	}
 
 	server, err := webhook.NewServer(ctx, h, cfg, opts)

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	ExtraRunnerCount          string `env:"EXTRA_RUNNER_COUNT,default=0"`
 	RunnerWorkerPoolID        string `env:"RUNNER_WORKER_POOL_ID"`
 	E2ETestRunID              string `env:"E2E_TEST_RUN_ID"`
+	RunnerLabel               string `env:"RUNNER_LABEL,default=self-hosted"`
 }
 
 // Validate validates the webhook config after load.
@@ -86,6 +87,10 @@ func (cfg *Config) Validate() error {
 
 	if _, err := validateExtraRunnerCount(cfg.ExtraRunnerCount); err != nil {
 		return err
+	}
+
+	if cfg.RunnerLabel == "" {
+		return fmt.Errorf("RUNNER_LABEL is required")
 	}
 
 	return nil
@@ -233,6 +238,14 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 		Target: &cfg.RunnerWorkerPoolID,
 		EnvVar: "RUNNER_WORKER_POOL_ID",
 		Usage:  `The private runner worker pool ID`,
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:    "runner-label",
+		Target:  &cfg.RunnerLabel,
+		EnvVar:  "RUNNER_LABEL",
+		Default: "self-hosted",
+		Usage:   `The single, exact label that the webhook will process for self-hosted runners.`,
 	})
 
 	return set

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -90,7 +90,7 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 
-	if strings.TrimSpace(cfg.RunnerLabel )== "" {
+	if strings.TrimSpace(cfg.RunnerLabel) == "" {
 		return fmt.Errorf("RUNNER_LABEL is required")
 	}
 

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -89,7 +89,7 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 
-	if cfg.RunnerLabel == "" {
+	if strings.TrimSpace(cfg.RunnerLabel )== "" {
 		return fmt.Errorf("RUNNER_LABEL is required")
 	}
 

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/sethvargo/go-envconfig"
 

--- a/pkg/webhook/config_test.go
+++ b/pkg/webhook/config_test.go
@@ -40,112 +40,68 @@ func TestConfig_Validate(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name   string
-		cfg    *Config
-		expErr string
+		name    string
+		mutator func(c *Config)
+		expErr  string
 	}{
 		{
-			name: "valid",
-			cfg:  generateValidConfig(),
+			name:    "valid",
+			mutator: nil,
 		},
 		{
-			name: "invalid_runner_label",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.RunnerLabel = ""
-				return c
-			}(),
-			expErr: "RUNNER_LABEL is required",
+			name:    "invalid_runner_label",
+			mutator: func(c *Config) { c.RunnerLabel = "" },
+			expErr:  "RUNNER_LABEL is required",
 		},
 		{
-			name: "invalid_environment",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.Environment = "invalid"
-				return c
-			}(),
-			expErr: `ENVIRONMENT must be one of 'production' or 'autopush', got "invalid"`,
+			name:    "invalid_environment",
+			mutator: func(c *Config) { c.Environment = "invalid" },
+			expErr:  `ENVIRONMENT must be one of 'production' or 'autopush', got "invalid"`,
 		},
 		{
-			name: "missing_github_app_id",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.GitHubAppID = ""
-				return c
-			}(),
-			expErr: "GITHUB_APP_ID is required",
+			name:    "missing_github_app_id",
+			mutator: func(c *Config) { c.GitHubAppID = "" },
+			expErr:  "GITHUB_APP_ID is required",
 		},
 		{
-			name: "missing_webhook_key_mount_path",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.GitHubWebhookKeyMountPath = ""
-				return c
-			}(),
-			expErr: "WEBHOOK_KEY_MOUNT_PATH is required",
+			name:    "missing_webhook_key_mount_path",
+			mutator: func(c *Config) { c.GitHubWebhookKeyMountPath = "" },
+			expErr:  "WEBHOOK_KEY_MOUNT_PATH is required",
 		},
 		{
-			name: "missing_webhook_key_name",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.GitHubWebhookKeyName = ""
-				return c
-			}(),
-			expErr: "WEBHOOK_KEY_NAME is required",
+			name:    "missing_webhook_key_name",
+			mutator: func(c *Config) { c.GitHubWebhookKeyName = "" },
+			expErr:  "WEBHOOK_KEY_NAME is required",
 		},
 		{
-			name: "missing_kms_app_private_key_id",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.KMSAppPrivateKeyID = ""
-				return c
-			}(),
-			expErr: "KMS_APP_PRIVATE_KEY_ID is required",
+			name:    "missing_kms_app_private_key_id",
+			mutator: func(c *Config) { c.KMSAppPrivateKeyID = "" },
+			expErr:  "KMS_APP_PRIVATE_KEY_ID is required",
 		},
 		{
-			name: "missing_runner_location",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.RunnerLocation = ""
-				return c
-			}(),
-			expErr: "RUNNER_LOCATION is required",
+			name:    "missing_runner_location",
+			mutator: func(c *Config) { c.RunnerLocation = "" },
+			expErr:  "RUNNER_LOCATION is required",
 		},
 		{
-			name: "missing_runner_project_id",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.RunnerProjectID = ""
-				return c
-			}(),
-			expErr: "RUNNER_PROJECT_ID is required",
+			name:    "missing_runner_project_id",
+			mutator: func(c *Config) { c.RunnerProjectID = "" },
+			expErr:  "RUNNER_PROJECT_ID is required",
 		},
 		{
-			name: "missing_runner_repository_id",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.RunnerRepositoryID = ""
-				return c
-			}(),
-			expErr: "RUNNER_REPOSITORY_ID is required",
+			name:    "missing_runner_repository_id",
+			mutator: func(c *Config) { c.RunnerRepositoryID = "" },
+			expErr:  "RUNNER_REPOSITORY_ID is required",
 		},
 		{
-			name: "missing_runner_service_account",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.RunnerServiceAccount = ""
-				return c
-			}(),
-			expErr: "RUNNER_SERVICE_ACCOUNT is required",
+			name:    "missing_runner_service_account",
+			mutator: func(c *Config) { c.RunnerServiceAccount = "" },
+			expErr:  "RUNNER_SERVICE_ACCOUNT is required",
 		},
 		{
-			name: "invalid_extra_runner_count",
-			cfg: func() *Config {
-				c := generateValidConfig()
-				c.ExtraRunnerCount = "abc"
-				return c
-			}(),
-			expErr: "EXTRA_RUNNER_COUNT must be an integer",
+			name:    "invalid_extra_runner_count",
+			mutator: func(c *Config) { c.ExtraRunnerCount = "abc" },
+			expErr:  "EXTRA_RUNNER_COUNT must be an integer",
 		},
 	}
 
@@ -153,7 +109,12 @@ func TestConfig_Validate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := tc.cfg.Validate()
+			cfg := generateValidConfig()
+			if tc.mutator != nil {
+				tc.mutator(cfg)
+			}
+
+			err := cfg.Validate()
 			if diff := testutil.DiffErrString(err, tc.expErr); diff != "" {
 				t.Fatal(diff)
 			}

--- a/pkg/webhook/config_test.go
+++ b/pkg/webhook/config_test.go
@@ -1,0 +1,184 @@
+// Copyright 2025 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"testing"
+
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		cfg    *Config
+		expErr string
+	}{
+		{
+			name: "valid",
+			cfg: &Config{
+				Environment:               "production",
+				GitHubAppID:               "test-app-id",
+				GitHubWebhookKeyMountPath: "/tmp",
+				GitHubWebhookKeyName:      "test-key",
+				KMSAppPrivateKeyID:        "test-kms-key",
+				RunnerLocation:            "test-location",
+				RunnerProjectID:           "test-project",
+				RunnerRepositoryID:        "test-repo",
+				RunnerServiceAccount:      "test-sa",
+				RunnerLabel:               "self-hosted",
+				ExtraRunnerCount:          "0",
+			},
+		},
+		{
+			name: "invalid_environment",
+			cfg: &Config{
+				Environment: "invalid",
+			},
+			expErr: `ENVIRONMENT must be one of 'production' or 'autopush', got "invalid"`,
+		},
+		{
+			name: "missing_github_app_id",
+			cfg: &Config{
+				Environment: "production",
+			},
+			expErr: "GITHUB_APP_ID is required",
+		},
+		{
+			name: "missing_webhook_key_mount_path",
+			cfg: &Config{
+				Environment: "production",
+				GitHubAppID: "test-app-id",
+			},
+			expErr: "WEBHOOK_KEY_MOUNT_PATH is required",
+		},
+		{
+			name: "missing_webhook_key_name",
+			cfg: &Config{
+				Environment:               "production",
+				GitHubAppID:               "test-app-id",
+				GitHubWebhookKeyMountPath: "/tmp",
+			},
+			expErr: "WEBHOOK_KEY_NAME is required",
+		},
+		{
+			name: "missing_kms_app_private_key_id",
+			cfg: &Config{
+				Environment:               "production",
+				GitHubAppID:               "test-app-id",
+				GitHubWebhookKeyMountPath: "/tmp",
+				GitHubWebhookKeyName:      "test-key",
+			},
+			expErr: "KMS_APP_PRIVATE_KEY_ID is required",
+		},
+		{
+			name: "missing_runner_location",
+			cfg: &Config{
+				Environment:               "production",
+				GitHubAppID:               "test-app-id",
+				GitHubWebhookKeyMountPath: "/tmp",
+				GitHubWebhookKeyName:      "test-key",
+				KMSAppPrivateKeyID:        "test-kms-key",
+			},
+			expErr: "RUNNER_LOCATION is required",
+		},
+		{
+			name: "missing_runner_project_id",
+			cfg: &Config{
+				Environment:               "production",
+				GitHubAppID:               "test-app-id",
+				GitHubWebhookKeyMountPath: "/tmp",
+				GitHubWebhookKeyName:      "test-key",
+				KMSAppPrivateKeyID:        "test-kms-key",
+				RunnerLocation:            "test-location",
+			},
+			expErr: "RUNNER_PROJECT_ID is required",
+		},
+		{
+			name: "missing_runner_repository_id",
+			cfg: &Config{
+				Environment:               "production",
+				GitHubAppID:               "test-app-id",
+				GitHubWebhookKeyMountPath: "/tmp",
+				GitHubWebhookKeyName:      "test-key",
+				KMSAppPrivateKeyID:        "test-kms-key",
+				RunnerLocation:            "test-location",
+				RunnerProjectID:           "test-project",
+			},
+			expErr: "RUNNER_REPOSITORY_ID is required",
+		},
+		{
+			name: "missing_runner_service_account",
+			cfg: &Config{
+				Environment:               "production",
+				GitHubAppID:               "test-app-id",
+				GitHubWebhookKeyMountPath: "/tmp",
+				GitHubWebhookKeyName:      "test-key",
+				KMSAppPrivateKeyID:        "test-kms-key",
+				RunnerLocation:            "test-location",
+				RunnerProjectID:           "test-project",
+				RunnerRepositoryID:        "test-repo",
+			},
+			expErr: "RUNNER_SERVICE_ACCOUNT is required",
+		},
+		{
+			name: "invalid_extra_runner_count",
+			cfg: &Config{
+				Environment:               "production",
+				GitHubAppID:               "test-app-id",
+				GitHubWebhookKeyMountPath: "/tmp",
+				GitHubWebhookKeyName:      "test-key",
+				KMSAppPrivateKeyID:        "test-kms-key",
+				RunnerLocation:            "test-location",
+				RunnerProjectID:           "test-project",
+				RunnerRepositoryID:        "test-repo",
+				RunnerServiceAccount:      "test-sa",
+				RunnerLabel:               "self-hosted",
+				ExtraRunnerCount:          "abc",
+			},
+			expErr: "EXTRA_RUNNER_COUNT must be an integer",
+		},
+		{
+			name: "invalid_runner_label",
+			cfg: &Config{
+				Environment:               "production",
+				GitHubAppID:               "test-app-id",
+				GitHubWebhookKeyMountPath: "/tmp",
+				GitHubWebhookKeyName:      "test-key",
+				KMSAppPrivateKeyID:        "test-kms-key",
+				RunnerLocation:            "test-location",
+				RunnerProjectID:           "test-project",
+				RunnerRepositoryID:        "test-repo",
+				RunnerServiceAccount:      "test-sa",
+				RunnerLabel:               "",
+				ExtraRunnerCount:          "0",
+			},
+			expErr: "RUNNER_LABEL is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.cfg.Validate()
+			if diff := testutil.DiffErrString(err, tc.expErr); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/pkg/webhook/config_test.go
+++ b/pkg/webhook/config_test.go
@@ -20,154 +20,132 @@ import (
 	"github.com/abcxyz/pkg/testutil"
 )
 
+func generateValidConfig() *Config {
+	return &Config{
+		Environment:               "production",
+		GitHubAppID:               "test-app-id",
+		GitHubWebhookKeyMountPath: "/tmp",
+		GitHubWebhookKeyName:      "test-key",
+		KMSAppPrivateKeyID:        "test-kms-key",
+		RunnerLocation:            "test-location",
+		RunnerProjectID:           "test-project",
+		RunnerRepositoryID:        "test-repo",
+		RunnerServiceAccount:      "test-sa",
+		RunnerLabel:               "self-hosted",
+		ExtraRunnerCount:          "0",
+	}
+}
+
 func TestConfig_Validate(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name   string
-		cfg    *Config
-		expErr string
+		name    string
+		cfg     *Config
+		expErr  string
 	}{
 		{
 			name: "valid",
-			cfg: &Config{
-				Environment:               "production",
-				GitHubAppID:               "test-app-id",
-				GitHubWebhookKeyMountPath: "/tmp",
-				GitHubWebhookKeyName:      "test-key",
-				KMSAppPrivateKeyID:        "test-kms-key",
-				RunnerLocation:            "test-location",
-				RunnerProjectID:           "test-project",
-				RunnerRepositoryID:        "test-repo",
-				RunnerServiceAccount:      "test-sa",
-				RunnerLabel:               "self-hosted",
-				ExtraRunnerCount:          "0",
-			},
+			cfg:  generateValidConfig(),
+		},
+		{
+			name: "invalid_runner_label",
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.RunnerLabel = ""
+				return c
+			}(),
+			expErr: "RUNNER_LABEL is required",
 		},
 		{
 			name: "invalid_environment",
-			cfg: &Config{
-				Environment: "invalid",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.Environment = "invalid"
+				return c
+			}(),
 			expErr: `ENVIRONMENT must be one of 'production' or 'autopush', got "invalid"`,
 		},
 		{
 			name: "missing_github_app_id",
-			cfg: &Config{
-				Environment: "production",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.GitHubAppID = ""
+				return c
+			}(),
 			expErr: "GITHUB_APP_ID is required",
 		},
 		{
 			name: "missing_webhook_key_mount_path",
-			cfg: &Config{
-				Environment: "production",
-				GitHubAppID: "test-app-id",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.GitHubWebhookKeyMountPath = ""
+				return c
+			}(),
 			expErr: "WEBHOOK_KEY_MOUNT_PATH is required",
 		},
 		{
 			name: "missing_webhook_key_name",
-			cfg: &Config{
-				Environment:               "production",
-				GitHubAppID:               "test-app-id",
-				GitHubWebhookKeyMountPath: "/tmp",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.GitHubWebhookKeyName = ""
+				return c
+			}(),
 			expErr: "WEBHOOK_KEY_NAME is required",
 		},
 		{
 			name: "missing_kms_app_private_key_id",
-			cfg: &Config{
-				Environment:               "production",
-				GitHubAppID:               "test-app-id",
-				GitHubWebhookKeyMountPath: "/tmp",
-				GitHubWebhookKeyName:      "test-key",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.KMSAppPrivateKeyID = ""
+				return c
+			}(),
 			expErr: "KMS_APP_PRIVATE_KEY_ID is required",
 		},
 		{
 			name: "missing_runner_location",
-			cfg: &Config{
-				Environment:               "production",
-				GitHubAppID:               "test-app-id",
-				GitHubWebhookKeyMountPath: "/tmp",
-				GitHubWebhookKeyName:      "test-key",
-				KMSAppPrivateKeyID:        "test-kms-key",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.RunnerLocation = ""
+				return c
+			}(),
 			expErr: "RUNNER_LOCATION is required",
 		},
 		{
 			name: "missing_runner_project_id",
-			cfg: &Config{
-				Environment:               "production",
-				GitHubAppID:               "test-app-id",
-				GitHubWebhookKeyMountPath: "/tmp",
-				GitHubWebhookKeyName:      "test-key",
-				KMSAppPrivateKeyID:        "test-kms-key",
-				RunnerLocation:            "test-location",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.RunnerProjectID = ""
+				return c
+			}(),
 			expErr: "RUNNER_PROJECT_ID is required",
 		},
 		{
 			name: "missing_runner_repository_id",
-			cfg: &Config{
-				Environment:               "production",
-				GitHubAppID:               "test-app-id",
-				GitHubWebhookKeyMountPath: "/tmp",
-				GitHubWebhookKeyName:      "test-key",
-				KMSAppPrivateKeyID:        "test-kms-key",
-				RunnerLocation:            "test-location",
-				RunnerProjectID:           "test-project",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.RunnerRepositoryID = ""
+				return c
+			}(),
 			expErr: "RUNNER_REPOSITORY_ID is required",
 		},
 		{
 			name: "missing_runner_service_account",
-			cfg: &Config{
-				Environment:               "production",
-				GitHubAppID:               "test-app-id",
-				GitHubWebhookKeyMountPath: "/tmp",
-				GitHubWebhookKeyName:      "test-key",
-				KMSAppPrivateKeyID:        "test-kms-key",
-				RunnerLocation:            "test-location",
-				RunnerProjectID:           "test-project",
-				RunnerRepositoryID:        "test-repo",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.RunnerServiceAccount = ""
+				return c
+			}(),
 			expErr: "RUNNER_SERVICE_ACCOUNT is required",
 		},
 		{
 			name: "invalid_extra_runner_count",
-			cfg: &Config{
-				Environment:               "production",
-				GitHubAppID:               "test-app-id",
-				GitHubWebhookKeyMountPath: "/tmp",
-				GitHubWebhookKeyName:      "test-key",
-				KMSAppPrivateKeyID:        "test-kms-key",
-				RunnerLocation:            "test-location",
-				RunnerProjectID:           "test-project",
-				RunnerRepositoryID:        "test-repo",
-				RunnerServiceAccount:      "test-sa",
-				RunnerLabel:               "self-hosted",
-				ExtraRunnerCount:          "abc",
-			},
+			cfg: func() *Config {
+				c := generateValidConfig()
+				c.ExtraRunnerCount = "abc"
+				return c
+			}(),
 			expErr: "EXTRA_RUNNER_COUNT must be an integer",
-		},
-		{
-			name: "invalid_runner_label",
-			cfg: &Config{
-				Environment:               "production",
-				GitHubAppID:               "test-app-id",
-				GitHubWebhookKeyMountPath: "/tmp",
-				GitHubWebhookKeyName:      "test-key",
-				KMSAppPrivateKeyID:        "test-kms-key",
-				RunnerLocation:            "test-location",
-				RunnerProjectID:           "test-project",
-				RunnerRepositoryID:        "test-repo",
-				RunnerServiceAccount:      "test-sa",
-				RunnerLabel:               "",
-				ExtraRunnerCount:          "0",
-			},
-			expErr: "RUNNER_LABEL is required",
 		},
 	}
 
@@ -182,3 +160,4 @@ func TestConfig_Validate(t *testing.T) {
 		})
 	}
 }
+

--- a/pkg/webhook/config_test.go
+++ b/pkg/webhook/config_test.go
@@ -40,9 +40,9 @@ func TestConfig_Validate(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name    string
-		cfg     *Config
-		expErr  string
+		name   string
+		cfg    *Config
+		expErr string
 	}{
 		{
 			name: "valid",
@@ -160,4 +160,3 @@ func TestConfig_Validate(t *testing.T) {
 		})
 	}
 }
-

--- a/pkg/webhook/github.go
+++ b/pkg/webhook/github.go
@@ -24,15 +24,15 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func (s *Server) GenerateRepoJITConfig(ctx context.Context, installationID int64, org, repo, runnerName string) (*github.JITRunnerConfig, error) {
-	return s.generateJITConfig(ctx, installationID, org, &repo, runnerName)
+func (s *Server) GenerateRepoJITConfig(ctx context.Context, installationID int64, org, repo, runnerName, runnerLabel string) (*github.JITRunnerConfig, error) {
+	return s.generateJITConfig(ctx, installationID, org, &repo, runnerName, runnerLabel)
 }
 
-func (s *Server) GenerateOrgJITConfig(ctx context.Context, installationID int64, org, runnerName string) (*github.JITRunnerConfig, error) {
-	return s.generateJITConfig(ctx, installationID, org, nil, runnerName)
+func (s *Server) GenerateOrgJITConfig(ctx context.Context, installationID int64, org, runnerName, runnerLabel string) (*github.JITRunnerConfig, error) {
+	return s.generateJITConfig(ctx, installationID, org, nil, runnerName, runnerLabel)
 }
 
-func (s *Server) generateJITConfig(ctx context.Context, installationID int64, org string, repo *string, runnerName string) (*github.JITRunnerConfig, error) {
+func (s *Server) generateJITConfig(ctx context.Context, installationID int64, org string, repo *string, runnerName, runnerLabel string) (*github.JITRunnerConfig, error) {
 	installation, err := s.appClient.InstallationForID(ctx, strconv.FormatInt(installationID, 10))
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup installation client: %w", err)
@@ -57,7 +57,7 @@ func (s *Server) generateJITConfig(ctx context.Context, installationID int64, or
 	jitRequest := &github.GenerateJITConfigRequest{
 		Name:          runnerName,
 		RunnerGroupID: 1,
-		Labels:        []string{defaultRunnerLabel, "Linux", "X64"},
+		Labels:        []string{runnerLabel},
 	}
 
 	var jitConfig *github.JITRunnerConfig

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -50,6 +50,7 @@ type Server struct {
 	runnerWorkerPoolID   string
 	webhookSecret        []byte
 	e2eTestRunID         string
+	runnerLabel          string
 }
 
 // FileReader can read a file and return the content.
@@ -150,6 +151,7 @@ func NewServer(ctx context.Context, h *renderer.Renderer, cfg *Config, wco *Webh
 		runnerWorkerPoolID:   cfg.RunnerWorkerPoolID,
 		webhookSecret:        webhookSecret,
 		e2eTestRunID:         cfg.E2ETestRunID,
+		runnerLabel:          cfg.RunnerLabel,
 	}, nil
 }
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -142,7 +142,7 @@ func (s *Server) handleQueuedEvent(ctx context.Context, event *github.WorkflowJo
 	logger := logging.FromContext(ctx)
 	logger.InfoContext(ctx, "Workflow job queued")
 
-	if !slices.Contains(event.WorkflowJob.Labels, defaultRunnerLabel) {
+	if !slices.Contains(event.WorkflowJob.Labels, s.runnerLabel) {
 		logger.WarnContext(ctx, "no action taken for labels", "labels", event.WorkflowJob.Labels)
 		return &apiResponse{http.StatusOK, fmt.Sprintf("no action taken for labels: %s", event.WorkflowJob.Labels), nil}
 	}
@@ -254,7 +254,7 @@ func compressAndBase64EncodeString(input string) (string, error) {
 }
 
 func (s *Server) startGitHubRunner(ctx context.Context, event *github.WorkflowJobEvent, runnerID string, logger *slog.Logger, imageTag string) (string, error) {
-	jitConfig, err := s.GenerateRepoJITConfig(ctx, *event.Installation.ID, *event.Org.Login, *event.Repo.Name, runnerID)
+	jitConfig, err := s.GenerateRepoJITConfig(ctx, *event.Installation.ID, *event.Org.Login, *event.Repo.Name, runnerID, s.runnerLabel)
 	if err != nil {
 		logger.ErrorContext(ctx, "failed to generate JIT config",
 			"error", err.Error(),

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -64,6 +64,7 @@ func TestHandleWebhook(t *testing.T) {
 		action               string
 		runnerLabels         []string
 		payloadWebhookSecret string
+		serverRunnerLabel    string
 		extraSpawnNumber     int
 		contentType          string
 		createdAt            *github.Timestamp
@@ -83,6 +84,26 @@ func TestHandleWebhook(t *testing.T) {
 			action:               queuedAction,
 			runnerLabels:         []string{defaultRunnerLabel},
 			payloadWebhookSecret: serverGitHubWebhookSecret,
+			serverRunnerLabel:    "self-hosted",
+			contentType:          contentType,
+			createdAt:            &queuedTime,
+			startedAt:            nil,
+			completedAt:          nil,
+			runID:                &runID,
+			jobID:                &jobID,
+			jobName:              &jobName,
+			expStatusCode:        200,
+			expRespBody:          runnerStartedMsg,
+			expectBuildCount:     1,
+			expectedImageTag:     "latest",
+		},
+		{
+			name:                 "Workflow Job Queued - Custom Label",
+			payloadType:          payloadType,
+			action:               queuedAction,
+			runnerLabels:         []string{"custom-label"},
+			payloadWebhookSecret: serverGitHubWebhookSecret,
+			serverRunnerLabel:    "custom-label",
 			contentType:          contentType,
 			createdAt:            &queuedTime,
 			startedAt:            nil,
@@ -101,6 +122,7 @@ func TestHandleWebhook(t *testing.T) {
 			action:               queuedAction,
 			runnerLabels:         []string{defaultRunnerLabel, "pr-123-abc"},
 			payloadWebhookSecret: serverGitHubWebhookSecret,
+			serverRunnerLabel:    "self-hosted",
 			contentType:          contentType,
 			createdAt:            &queuedTime,
 			startedAt:            nil,
@@ -119,6 +141,7 @@ func TestHandleWebhook(t *testing.T) {
 			action:               queuedAction,
 			runnerLabels:         []string{defaultRunnerLabel, "pr-123-abc"},
 			payloadWebhookSecret: serverGitHubWebhookSecret,
+			serverRunnerLabel:    "self-hosted",
 			contentType:          contentType,
 			createdAt:            &queuedTime,
 			startedAt:            nil,
@@ -137,6 +160,7 @@ func TestHandleWebhook(t *testing.T) {
 			action:               queuedAction,
 			runnerLabels:         []string{defaultRunnerLabel},
 			payloadWebhookSecret: serverGitHubWebhookSecret,
+			serverRunnerLabel:    "self-hosted",
 			extraSpawnNumber:     2,
 			contentType:          contentType,
 			createdAt:            &queuedTime,
@@ -156,6 +180,7 @@ func TestHandleWebhook(t *testing.T) {
 			action:               queuedAction,
 			runnerLabels:         []string{"other-label"}, // No defaultRunnerLabel
 			payloadWebhookSecret: serverGitHubWebhookSecret,
+			serverRunnerLabel:    "self-hosted",
 			contentType:          contentType,
 			createdAt:            &queuedTime,
 			startedAt:            nil,
@@ -173,6 +198,7 @@ func TestHandleWebhook(t *testing.T) {
 			action:               "in_progress",
 			runnerLabels:         []string{defaultRunnerLabel},
 			payloadWebhookSecret: serverGitHubWebhookSecret,
+			serverRunnerLabel:    "self-hosted",
 			contentType:          contentType,
 			createdAt:            &queuedTime,
 			startedAt:            &inProgressTime,
@@ -190,6 +216,7 @@ func TestHandleWebhook(t *testing.T) {
 			action:               "completed",
 			runnerLabels:         []string{defaultRunnerLabel},
 			payloadWebhookSecret: serverGitHubWebhookSecret,
+			serverRunnerLabel:    "self-hosted",
 			contentType:          contentType,
 			createdAt:            &queuedTime,
 			startedAt:            &inProgressTime,
@@ -302,6 +329,7 @@ func TestHandleWebhook(t *testing.T) {
 				runnerImageTag:   "latest",
 				extraRunnerCount: tc.extraSpawnNumber,
 				environment:      testEnv,
+				runnerLabel:      tc.serverRunnerLabel,
 			}
 			srv.handleWebhook().ServeHTTP(resp, req)
 


### PR DESCRIPTION
This change introduces a new --runner-label flag to the webhook server. This allows the webhook to process jobs for a single, specific runner label, rather than a hardcoded list.