### PR TITLE
change integration test to use new runner name

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,6 +24,7 @@ on:
           - 'self-hosted-autopush'
           - 'self-hosted-integration'
           - 'self-hosted'
+          - 'ubuntu-2c-8g'
           - 'ubuntu-latest'
   workflow_run:
     # Run this workflow after runner image is pushed.


### PR DESCRIPTION
I put in ubuntu-2c-8g as a placeholder instead of self-hosted.

This will probably not be the final naming convention, but I prefer capabatility based names.