### PR TITLE
Transfer ownership of the home directory the runner

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -170,6 +170,9 @@ RUN chmod +x /usr/local/bin/setup_docker.sh
 RUN chmod -R 777 /opt && \
     chmod -R 777 /usr/share
 
+# This allows the runner user to add more folders under HOME
+RUN chown -R runner:runner /home/runner
+
 WORKDIR /home/runner
 
 # We need to do some setup as the runner


### PR DESCRIPTION
The following [build failure](https://github.com/abcxyz/github-action-dispatcher/actions/runs/18103211267/job/51525199804) was observed which indicates that the runner user was previously creating resources within the home directory. Now the root user is copying resources into the home directory (via [this change](https://github.com/abcxyz/github-action-dispatcher/pull/158) where the externals folder is copied into home. 