### PR TITLE
Also push next/cur/stage runner images to abcxyz-artifacts registry

### DIFF
--- a/.github/workflows/promote-runner-to-production.yml
+++ b/.github/workflows/promote-runner-to-production.yml
@@ -19,6 +19,8 @@ env:
   WIF_SERVICE_ACCOUNT: 'github-automation-bot@gha-on-gcp-p-a63b4c.iam.gserviceaccount.com'
   GAR_LOCATION: 'us'
   GAR_IMAGE_NAME: 'ghss-artifacts-p-25/docker-images/gha-runner'
+  ABCXYZ_GAR_LOCATION: 'us'
+  ABCXYZ_GAR_IMAGE_NAME: 'abcxyz-artifacts/docker-images/gha-runner'
 
 permissions:
   contents: 'read'
@@ -50,10 +52,18 @@ jobs:
           password: '${{ steps.auth.outputs.access_token }}'
           registry: '${{ env.GAR_LOCATION }}-docker.pkg.dev'
 
+      - if: "${{ env.GAR_LOCATION != env.ABCXYZ_GAR_LOCATION }}"
+        uses: 'docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc' # ratchet:docker/login-action@v2
+        with:
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
+          registry: '${{ env.ABCXYZ_GAR_LOCATION }}-docker.pkg.dev'
+
       - name: 'Promote Images'
         run: |
           set -e
           IMAGE_URI="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GAR_IMAGE_NAME }}"
+          ABCXYZ_IMAGE_URI="${{ env.ABCXYZ_GAR_LOCATION }}-docker.pkg.dev/${{ env.ABCXYZ_GAR_IMAGE_NAME }}"
 
           MANUAL_CUR_TAG="${{ github.event.inputs.manual_cur_tag }}"
           MANUAL_PREV_TAG="${{ github.event.inputs.manual_prev_tag }}"
@@ -66,21 +76,26 @@ jobs:
               echo "Manual override for 'prev' tag also detected. Setting 'prev' to point to image with tag ${MANUAL_PREV_TAG}"
               docker pull "${IMAGE_URI}:${MANUAL_PREV_TAG}"
               docker tag "${IMAGE_URI}:${MANUAL_PREV_TAG}" "${IMAGE_URI}:prev"
+              docker tag "${IMAGE_URI}:${MANUAL_PREV_TAG}" "${ABCXYZ_IMAGE_URI}:prev"
             else
               echo "No manual 'prev' tag. Setting 'prev' to the current 'cur'."
               docker pull "${IMAGE_URI}:cur"
               docker tag "${IMAGE_URI}:cur" "${IMAGE_URI}:prev"
+              docker tag "${IMAGE_URI}:cur" "${ABCXYZ_IMAGE_URI}:prev"
             fi
 
             # Now set the new 'cur' tag
             echo "Setting 'cur' to point to image with tag ${MANUAL_CUR_TAG}"
             docker pull "${IMAGE_URI}:${MANUAL_CUR_TAG}"
             docker tag "${IMAGE_URI}:${MANUAL_CUR_TAG}" "${IMAGE_URI}:cur"
+            docker tag "${IMAGE_URI}:${MANUAL_CUR_TAG}" "${ABCXYZ_IMAGE_URI}:cur"
 
             # Push both tags
             echo "Pushing new 'cur' and 'prev' tags."
             docker push "${IMAGE_URI}:cur"
+            docker push "${ABCXYZ_IMAGE_URI}:cur"
             docker push "${IMAGE_URI}:prev"
+            docker push "${ABCXYZ_IMAGE_URI}:prev"
           else
             echo "No manual overrides. Running automatic promotion."
             docker pull "${IMAGE_URI}:next"
@@ -92,9 +107,13 @@ jobs:
             if [ "${NEXT_DIGEST}" != "${CUR_DIGEST}" ]; then
               echo "Promoting 'next' to 'cur'"
               docker tag "${IMAGE_URI}:cur" "${IMAGE_URI}:prev"
+              docker tag "${IMAGE_URI}:cur" "${ABCXYZ_IMAGE_URI}:prev"
               docker push "${IMAGE_URI}:prev"
+              docker push "${ABCXYZ_IMAGE_URI}:prev"
               docker tag "${IMAGE_URI}:next" "${IMAGE_URI}:cur"
+              docker tag "${IMAGE_URI}:next" "${ABCXYZ_IMAGE_URI}:cur"
               docker push "${IMAGE_URI}:cur"
+              docker push "${ABCXYZ_IMAGE_URI}:cur"
             else
               echo "'next' and 'cur' images are the same. No promotion needed."
             fi

--- a/.github/workflows/promote-runner-to-staging.yml
+++ b/.github/workflows/promote-runner-to-staging.yml
@@ -14,6 +14,8 @@ env:
   WIF_SERVICE_ACCOUNT: 'github-automation-bot@gha-on-gcp-p-a63b4c.iam.gserviceaccount.com'
   GAR_LOCATION: 'us'
   GAR_IMAGE_NAME: 'ghss-artifacts-p-25/docker-images/gha-runner'
+  ABCXYZ_GAR_LOCATION: 'us'
+  ABCXYZ_GAR_IMAGE_NAME: 'abcxyz-artifacts/docker-images/gha-runner'
 
 permissions:
   contents: 'read'
@@ -46,10 +48,18 @@ jobs:
           password: '${{ steps.auth.outputs.access_token }}'
           registry: '${{ env.GAR_LOCATION }}-docker.pkg.dev'
 
+      - if: "${{ env.GAR_LOCATION != env.ABCXYZ_GAR_LOCATION }}"
+        uses: 'docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc' # ratchet:docker/login-action@v2
+        with:
+          username: 'oauth2accesstoken'
+          password: '${{ steps.auth.outputs.access_token }}'
+          registry: '${{ env.ABCXYZ_GAR_LOCATION }}-docker.pkg.dev'
+
       - name: 'Tag and Push Image to next'
         run: |
           set -e
           IMAGE_URI="${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GAR_IMAGE_NAME }}"
+          ABCXYZ_IMAGE_URI="${{ env.ABCXYZ_GAR_LOCATION }}-docker.pkg.dev/${{ env.ABCXYZ_GAR_IMAGE_NAME }}"
           FULL_IMAGE_NAME="${IMAGE_URI}:${{ github.event.inputs.image-tag }}"
 
           echo "Pulling image: ${FULL_IMAGE_NAME}"
@@ -60,3 +70,10 @@ jobs:
 
           echo "Pushing ${IMAGE_URI}:next"
           docker push "${IMAGE_URI}:next"
+
+          echo "Tagging ${FULL_IMAGE_NAME} as ${ABCXYZ_IMAGE_URI}:next"
+          docker tag "${FULL_IMAGE_NAME}" "${ABCXYZ_IMAGE_URI}:next"
+
+          echo "Pushing ${ABCXYZ_IMAGE_URI}:next"
+          docker push "${ABCXYZ_IMAGE_URI}:next"
+        


### PR DESCRIPTION
This is a public registry, which is needed for some of our usecases.