### PR TITLE
Allow additionally accepting self-hosted label along with configured label

### DIFF
--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	RunnerWorkerPoolID        string `env:"RUNNER_WORKER_POOL_ID"`
 	E2ETestRunID              string `env:"E2E_TEST_RUN_ID"`
 	RunnerLabel               string `env:"RUNNER_LABEL,default=self-hosted"`
+	EnableSelfHostedLabel     bool   `env:"ENABLE_SELF_HOSTED_LABEL,default=false"`
 }
 
 // Validate validates the webhook config after load.
@@ -247,6 +248,13 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 		EnvVar:  "RUNNER_LABEL",
 		Default: "self-hosted",
 		Usage:   `The single, exact label that the webhook will process for self-hosted runners.`,
+	})
+
+	f.BoolVar(&cli.BoolVar{
+		Name:    "enable-self-hosted-label",
+		Usage:   "Enable to also allow self-hosted in addition to runner-label. Temporary until org registration is enabled.",
+		Default: false,
+		EnvVar:  "ENABLE_SELF_HOSTED_LABEL",
 	})
 
 	return set

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -34,23 +34,24 @@ import (
 
 // Server provides the server implementation.
 type Server struct {
-	appClient            *githubauth.App
-	cbc                  CloudBuildClient
-	environment          string
-	ghAPIBaseURL         string
-	h                    *renderer.Renderer
-	kmc                  KeyManagementClient
-	runnerLocation       string
-	runnerProjectID      string
-	runnerImageName      string
-	runnerImageTag       string
-	runnerRepositoryID   string
-	runnerServiceAccount string
-	extraRunnerCount     int
-	runnerWorkerPoolID   string
-	webhookSecret        []byte
-	e2eTestRunID         string
-	runnerLabel          string
+	appClient             *githubauth.App
+	cbc                   CloudBuildClient
+	environment           string
+	ghAPIBaseURL          string
+	h                     *renderer.Renderer
+	kmc                   KeyManagementClient
+	runnerLocation        string
+	runnerProjectID       string
+	runnerImageName       string
+	runnerImageTag        string
+	runnerRepositoryID    string
+	runnerServiceAccount  string
+	extraRunnerCount      int
+	runnerWorkerPoolID    string
+	webhookSecret         []byte
+	e2eTestRunID          string
+	runnerLabel           string
+	enableSelfHostedLabel bool
 }
 
 // FileReader can read a file and return the content.
@@ -135,23 +136,24 @@ func NewServer(ctx context.Context, h *renderer.Renderer, cfg *Config, wco *Webh
 	extraRunnerCount = num
 
 	return &Server{
-		appClient:            appClient,
-		cbc:                  cbc,
-		environment:          cfg.Environment,
-		ghAPIBaseURL:         cfg.GitHubAPIBaseURL,
-		h:                    h,
-		kmc:                  kmc,
-		runnerLocation:       cfg.RunnerLocation,
-		runnerImageName:      cfg.RunnerImageName,
-		runnerImageTag:       cfg.RunnerImageTag,
-		runnerProjectID:      cfg.RunnerProjectID,
-		runnerRepositoryID:   cfg.RunnerRepositoryID,
-		runnerServiceAccount: cfg.RunnerServiceAccount,
-		extraRunnerCount:     extraRunnerCount,
-		runnerWorkerPoolID:   cfg.RunnerWorkerPoolID,
-		webhookSecret:        webhookSecret,
-		e2eTestRunID:         cfg.E2ETestRunID,
-		runnerLabel:          cfg.RunnerLabel,
+		appClient:             appClient,
+		cbc:                   cbc,
+		environment:           cfg.Environment,
+		ghAPIBaseURL:          cfg.GitHubAPIBaseURL,
+		h:                     h,
+		kmc:                   kmc,
+		runnerLocation:        cfg.RunnerLocation,
+		runnerImageName:       cfg.RunnerImageName,
+		runnerImageTag:        cfg.RunnerImageTag,
+		runnerProjectID:       cfg.RunnerProjectID,
+		runnerRepositoryID:    cfg.RunnerRepositoryID,
+		runnerServiceAccount:  cfg.RunnerServiceAccount,
+		extraRunnerCount:      extraRunnerCount,
+		runnerWorkerPoolID:    cfg.RunnerWorkerPoolID,
+		webhookSecret:         webhookSecret,
+		e2eTestRunID:          cfg.E2ETestRunID,
+		runnerLabel:           cfg.RunnerLabel,
+		enableSelfHostedLabel: cfg.EnableSelfHostedLabel,
 	}, nil
 }
 


### PR DESCRIPTION
This is a temporary feature to allow us to migrate away from using self-hosted, as we need a state where both labels are accepted.

Once migration is complete, this should be deleted.

In the future we will have a registration service that handles multiple labels and target machine sizes.

Also:
- Remove dynamic `pr-` label/image tag as it was never used
- Enforce only single-tag jobs, as multi-tag jobs with a matching label will never be scheduled on a runner (a runner must satisfy all tags in a job, and we hard coded to only give a runner a single tag. 